### PR TITLE
Issue 199

### DIFF
--- a/features/de.cognicrypt.codegenerator.feature/pom.xml
+++ b/features/de.cognicrypt.codegenerator.feature/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../mvn-parent/</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>
 </project>

--- a/features/de.cognicrypt.cryslhandler.feature/pom.xml
+++ b/features/de.cognicrypt.cryslhandler.feature/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../mvn-parent/</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>
 </project>

--- a/features/de.cognicrypt.staticanalyzer.feature/pom.xml
+++ b/features/de.cognicrypt.staticanalyzer.feature/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../../mvn-parent/</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>
 </project>

--- a/mvn-parent/pom.xml
+++ b/mvn-parent/pom.xml
@@ -1,105 +1,122 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.cognicrypt</groupId>
   <artifactId>de.cognicrypt.parent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho-version>0.26.0</tycho-version>
-	</properties>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <tycho-version>0.26.0</tycho-version>
+  </properties>
 
-	<repositories>
-		<repository>
-			<id>eclipse-oxygen</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/oxygen</url>
-		</repository>
-		<repository>
-			<id>cryptsl</id>
-			<url>https://it.crossing.tu-darmstadt.de/cognicrypt/</url>
-			<layout>p2</layout>
-		</repository>
-		<repository>
-			<id>xtend</id>
-			<url>http://build.eclipse.org/common/xtend/maven/</url>
-		</repository>
-		<repository>
-			<id>xtext</id>
-			<layout>p2</layout>
-			<url>http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/</url>
-		</repository>
-	</repositories>
-	
-	<pluginRepositories>
-		<pluginRepository>
-			<id>jboss-public-repository-group</id>
-			<name>JBoss Public Repository Group</name>
-			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>jboss-snapshots-repository</id>
-			<name>JBoss Snapshots Repository</name>
-			<url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-		</pluginRepository>
-	</pluginRepositories>
+  <repositories>
+    <repository>
+      <id>eclipse-oxygen</id>
+      <layout>p2</layout>
+      <url>http://download.eclipse.org/releases/oxygen</url>
+    </repository>
+    <repository>
+      <id>cryptsl</id>
+      <url>https://it.crossing.tu-darmstadt.de/cognicrypt/</url>
+      <layout>p2</layout>
+    </repository>
+    <repository>
+      <id>xtend</id>
+      <url>http://build.eclipse.org/common/xtend/maven/</url>
+    </repository>
+    <repository>
+      <id>xtext</id>
+      <layout>p2</layout>
+      <url>http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/</url>
+    </repository>
+  </repositories>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<extensions>true</extensions>
-			</plugin>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>jboss-snapshots-repository</id>
+      <name>JBoss Snapshots Repository</name>
+      <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho-version}</version>
-				<configuration>
-					<environments>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
-							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>macosx</os>
-							<ws>cocoa</ws>
-							<arch>x86_64</arch>
-						</environment>
-					</environments>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	<modules>
-		<module>../plugins/de.cognicrypt.core/</module>
-		<module>../plugins/de.cognicrypt.codegenerator/</module>
-		<module>../plugins/de.cognicrypt.crysl.handler/</module>
-		<module>../plugins/de.cognicrypt.staticanalyzer/</module>
-		<module>../features/de.cognicrypt.codegenerator.feature/</module>
-		<module>../features/de.cognicrypt.cryslhandler.feature/</module>
-		<module>../features/de.cognicrypt.staticanalyzer.feature/</module>
-		<module>../repository/</module>
-	</modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <extensions>true</extensions>
+      </plugin>
+
+      <!-- Adding The Cobertura Maven Plugin to the parent POM File -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <maxmem>256m</maxmem>
+          <aggregate>true</aggregate>
+          <formats>
+            <format>html</format>
+            <format>xml</format>
+          </formats>
+          <outputDirectory>../shippable/codecoverage</outputDirectory>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <modules>
+    <module>../plugins/de.cognicrypt.core/</module>
+    <module>../plugins/de.cognicrypt.codegenerator/</module>
+    <module>../plugins/de.cognicrypt.crysl.handler/</module>
+    <module>../plugins/de.cognicrypt.staticanalyzer/</module>
+    <module>../features/de.cognicrypt.codegenerator.feature/</module>
+    <module>../features/de.cognicrypt.cryslhandler.feature/</module>
+    <module>../features/de.cognicrypt.staticanalyzer.feature/</module>
+    <module>../repository/</module>
+  </modules>
 </project>

--- a/plugins/de.cognicrypt.codegenerator/pom.xml
+++ b/plugins/de.cognicrypt.codegenerator/pom.xml
@@ -8,7 +8,7 @@
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../../mvn-parent</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <build>
@@ -67,7 +67,7 @@
         </executions>
       </plugin>
     </plugins>
-    
+
     <pluginManagement>
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/plugins/de.cognicrypt.codegenerator/pom.xml
+++ b/plugins/de.cognicrypt.codegenerator/pom.xml
@@ -1,160 +1,154 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>de.cognicrypt.codegenerator</artifactId>
   <packaging>eclipse-plugin</packaging>
-	<parent>
-  	<groupId>de.cognicrypt</groupId>
-  	<artifactId>de.cognicrypt.parent</artifactId>
-  	<version>1.0.0-SNAPSHOT</version>
-  	<relativePath>../../mvn-parent</relativePath>
+  <parent>
+    <groupId>de.cognicrypt</groupId>
+    <artifactId>de.cognicrypt.parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../mvn-parent</relativePath>
   </parent>
-	<repositories>
-	<repository>
-   <id>eclipse-oxygen</id>
-   <url>http://download.eclipse.org/releases/oxygen</url>
-   <layout>p2</layout>
-	</repository>
-	</repositories>
+
   <build>
-		
-<plugins>
+    <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
         <version>0.26.0</version>
         <extensions>true</extensions>
       </plugin>
-			<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-surefire-plugin</artifactId>
-    <version>2.17</version>
-		<configuration>
-      <reportsDirectory>../../shippable/testresults</reportsDirectory>
-    </configuration>
-		<dependencies>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
-      </dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-    </dependencies>
-  </plugin>
-	
-  <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.5.1</version>
-		<dependencies>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-		</dependencies>
-    <executions>
-      <execution>
-        <id>compiletests</id>
-        <phase>test-compile</phase>
-        <goals>
-          <goal>testCompile</goal>
-        </goals>
-				<configuration>
-				<testSourceDirectory>${project.basedir}\src\test\java\crossing\e1\featuremodel\clafer\test\*</testSourceDirectory>
-				<source>1.8</source>
-        <target>1.8</target>
-				</configuration>
-      </execution>
-    </executions>
-  </plugin>
+        <configuration>
+          <reportsDirectory>../../shippable/testresults</reportsDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.17</version>
+          </dependency>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>compiletests</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <testSourceDirectory>${project.basedir}\src\test\java\crossing\e1\featuremodel\clafer\test\*</testSourceDirectory>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+    
     <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-packaging-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>build-qualifier</goal>
-    									<goal>validate-id</goal>
-    									<goal>validate-version</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-compiler-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-compiler-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test-compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-surefire-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-packaging-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>build-qualifier</goal>
+                      <goal>validate-id</goal>
+                      <goal>validate-version</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-compiler-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test-compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
     </pluginManagement>
   </build>
   <groupId>de.cognicrypt</groupId>

--- a/plugins/de.cognicrypt.core/pom.xml
+++ b/plugins/de.cognicrypt.core/pom.xml
@@ -1,161 +1,155 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.cognicrypt</groupId>
   <artifactId>de.cognicrypt.core</artifactId>
   <packaging>eclipse-plugin</packaging>
-	<parent>
-  	<groupId>de.cognicrypt</groupId>
-  	<artifactId>de.cognicrypt.parent</artifactId>
-  	<version>1.0.0-SNAPSHOT</version>
-  	<relativePath>../../mvn-parent</relativePath>
+  <parent>
+    <groupId>de.cognicrypt</groupId>
+    <artifactId>de.cognicrypt.parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../mvn-parent</relativePath>
   </parent>
-	<repositories>
-	<repository>
-   <id>eclipse-oxygen</id>
-   <url>http://download.eclipse.org/releases/oxygen</url>
-   <layout>p2</layout>
-	</repository>
-	</repositories>
+
   <build>
-		
-<plugins>
+    <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
         <version>0.26.0</version>
         <extensions>true</extensions>
       </plugin>
-			<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-surefire-plugin</artifactId>
-    <version>2.17</version>
-		<configuration>
-      <reportsDirectory>../../shippable/testresults</reportsDirectory>
-    </configuration>
-		<dependencies>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
-      </dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-    </dependencies>
-  </plugin>
-	
-  <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.5.1</version>
-		<dependencies>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-		</dependencies>
-    <executions>
-      <execution>
-        <id>compiletests</id>
-        <phase>test-compile</phase>
-        <goals>
-          <goal>testCompile</goal>
-        </goals>
-				<configuration>
-				<testSourceDirectory>${project.basedir}\src\test\java\crossing\e1\featuremodel\clafer\test\*</testSourceDirectory>
-				<source>1.8</source>
-        <target>1.8</target>
-				</configuration>
-      </execution>
-    </executions>
-  </plugin>
+        <configuration>
+          <reportsDirectory>../../shippable/testresults</reportsDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.17</version>
+          </dependency>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>compiletests</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+    
     <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-packaging-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>build-qualifier</goal>
-    									<goal>validate-id</goal>
-    									<goal>validate-version</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-compiler-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-compiler-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test-compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-surefire-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-packaging-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>build-qualifier</goal>
+                      <goal>validate-id</goal>
+                      <goal>validate-version</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-compiler-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test-compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
     </pluginManagement>
   </build>
 </project>

--- a/plugins/de.cognicrypt.core/pom.xml
+++ b/plugins/de.cognicrypt.core/pom.xml
@@ -9,7 +9,7 @@
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../../mvn-parent</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <build>
@@ -68,7 +68,7 @@
         </executions>
       </plugin>
     </plugins>
-    
+
     <pluginManagement>
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/plugins/de.cognicrypt.crysl.handler/pom.xml
+++ b/plugins/de.cognicrypt.crysl.handler/pom.xml
@@ -9,7 +9,7 @@
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../../mvn-parent</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <build>

--- a/plugins/de.cognicrypt.crysl.handler/pom.xml
+++ b/plugins/de.cognicrypt.crysl.handler/pom.xml
@@ -1,180 +1,176 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.cognicrypt</groupId>
   <artifactId>de.cognicrypt.crysl.handler</artifactId>
   <packaging>eclipse-plugin</packaging>
-	<parent>
-  	<groupId>de.cognicrypt</groupId>
-  	<artifactId>de.cognicrypt.parent</artifactId>
-  	<version>1.0.0-SNAPSHOT</version>
-  	<relativePath>../../mvn-parent</relativePath>
+  <parent>
+    <groupId>de.cognicrypt</groupId>
+    <artifactId>de.cognicrypt.parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../mvn-parent</relativePath>
   </parent>
-	<repositories>
-	<repository>
-   <id>eclipse-oxygen</id>
-   <url>http://download.eclipse.org/releases/oxygen</url>
-   <layout>p2</layout>
-	</repository>
-	</repositories>
+
   <build>
-		
-<plugins>
+    <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
         <version>0.26.0</version>
         <extensions>true</extensions>
       </plugin>
-			<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-surefire-plugin</artifactId>
-    <version>2.17</version>
-		<configuration>
-      <reportsDirectory>../../shippable/testresults</reportsDirectory>
-    </configuration>
-		<dependencies>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
-      </dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-    </dependencies>
-  </plugin>
-	
-  <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.5.1</version>
-		<dependencies>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-		</dependencies>
-    <executions>
-      <execution>
-        <id>compiletests</id>
-        <phase>test-compile</phase>
-        <goals>
-          <goal>testCompile</goal>
-        </goals>
-				<configuration>
-				<source>1.8</source>
-        <target>1.8</target>
-				</configuration>
-      </execution>
-    </executions>
-  </plugin>
+        <configuration>
+          <reportsDirectory>../../shippable/testresults</reportsDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.17</version>
+          </dependency>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>compiletests</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+
     <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-packaging-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>build-qualifier</goal>
-    									<goal>validate-id</goal>
-    									<goal>validate-version</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-compiler-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-compiler-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test-compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-surefire-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-packaging-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>build-qualifier</goal>
+                      <goal>validate-id</goal>
+                      <goal>validate-version</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-compiler-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test-compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
     </pluginManagement>
   </build>
+
   <dependencies>
-  	<dependency>
-  		<groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
-  		<artifactId>de.darmstadt.tu.crossing.CryptSL</artifactId>
-  		<version>1.0.0-SNAPSHOT</version>
-  		<type>eclipse-plugin</type>
-  	</dependency>
-  	<dependency>
-  		<groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
-  		<artifactId>de.darmstadt.tu.crossing.CryptSL.ide</artifactId>
-  		<version>1.0.0-SNAPSHOT</version>
-  		<type>eclipse-plugin</type>
-  	</dependency>
-  	<dependency>
-  		<groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
-  		<artifactId>de.darmstadt.tu.crossing.CryptSL.ui</artifactId>
-  		<version>1.0.0-SNAPSHOT</version>
-  		<type>eclipse-plugin</type>
-  	</dependency>
+    <dependency>
+      <groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
+      <artifactId>de.darmstadt.tu.crossing.CryptSL</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <type>eclipse-plugin</type>
+    </dependency>
+    <dependency>
+      <groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
+      <artifactId>de.darmstadt.tu.crossing.CryptSL.ide</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <type>eclipse-plugin</type>
+    </dependency>
+    <dependency>
+      <groupId>de.darmstadt.tu.crossing.CryptSL</groupId>
+      <artifactId>de.darmstadt.tu.crossing.CryptSL.ui</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <type>eclipse-plugin</type>
+    </dependency>
   </dependencies>
 </project>

--- a/plugins/de.cognicrypt.staticanalyzer/pom.xml
+++ b/plugins/de.cognicrypt.staticanalyzer/pom.xml
@@ -9,7 +9,7 @@
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <relativePath>../../mvn-parent</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <build>

--- a/plugins/de.cognicrypt.staticanalyzer/pom.xml
+++ b/plugins/de.cognicrypt.staticanalyzer/pom.xml
@@ -1,160 +1,155 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.cognicrypt</groupId>
   <artifactId>de.cognicrypt.staticanalyzer</artifactId>
   <packaging>eclipse-plugin</packaging>
-	<parent>
-  	<groupId>de.cognicrypt</groupId>
-  	<artifactId>de.cognicrypt.parent</artifactId>
-  	<version>1.0.0-SNAPSHOT</version>
-  	<relativePath>../../mvn-parent</relativePath>
+  <parent>
+    <groupId>de.cognicrypt</groupId>
+    <artifactId>de.cognicrypt.parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../mvn-parent</relativePath>
   </parent>
-	<repositories>
-	<repository>
-   <id>eclipse-oxygen</id>
-   <url>http://download.eclipse.org/releases/oxygen</url>
-   <layout>p2</layout>
-	</repository>
-	</repositories>
+
   <build>
-		
-<plugins>
+    <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
         <version>0.26.0</version>
         <extensions>true</extensions>
       </plugin>
-			<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-surefire-plugin</artifactId>
-    <version>2.17</version>
-		<configuration>
-      <reportsDirectory>../../shippable/testresults</reportsDirectory>
-    </configuration>
-		<dependencies>
-      <dependency>
-        <groupId>org.apache.maven.surefire</groupId>
-        <artifactId>surefire-junit4</artifactId>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
-      </dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-    </dependencies>
-  </plugin>
-	
-  <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.5.1</version>
-		<dependencies>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.12</version>
-			</dependency>
-		</dependencies>
-    <executions>
-      <execution>
-        <id>compiletests</id>
-        <phase>test-compile</phase>
-        <goals>
-          <goal>testCompile</goal>
-        </goals>
-				<configuration>
-				<source>1.8</source>
-        <target>1.8</target>
-				</configuration>
-      </execution>
-    </executions>
-  </plugin>
+        <configuration>
+          <reportsDirectory>../../shippable/testresults</reportsDirectory>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit4</artifactId>
+            <version>2.17</version>
+          </dependency>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>compiletests</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
+
     <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-packaging-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>build-qualifier</goal>
-    									<goal>validate-id</goal>
-    									<goal>validate-version</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.eclipse.tycho</groupId>
-    								<artifactId>
-    									tycho-compiler-plugin
-    								</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-compiler-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test-compile</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-								<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-surefire-plugin</artifactId>
-    								<versionRange>
-    									[0.26.0,)
-    								</versionRange>
-    								<goals>
-    									<goal>test</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-packaging-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>build-qualifier</goal>
+                      <goal>validate-id</goal>
+                      <goal>validate-version</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>
+                      tycho-compiler-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test-compile</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <versionRange>
+                      [0.26.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>test</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
     </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
             <format>html</format>
             <format>xml</format>
           </formats>
-          <outputDirectory>../shippable/codecoverage</outputDirectory>
+          <outputDirectory>shippable/codecoverage</outputDirectory>
         </configuration>
       </plugin>
 
@@ -110,13 +110,13 @@
   </build>
 
   <modules>
-    <module>../plugins/de.cognicrypt.core/</module>
-    <module>../plugins/de.cognicrypt.codegenerator/</module>
-    <module>../plugins/de.cognicrypt.crysl.handler/</module>
-    <module>../plugins/de.cognicrypt.staticanalyzer/</module>
-    <module>../features/de.cognicrypt.codegenerator.feature/</module>
-    <module>../features/de.cognicrypt.cryslhandler.feature/</module>
-    <module>../features/de.cognicrypt.staticanalyzer.feature/</module>
-    <module>../repository/</module>
+    <module>plugins/de.cognicrypt.core/</module>
+    <module>plugins/de.cognicrypt.codegenerator/</module>
+    <module>plugins/de.cognicrypt.crysl.handler/</module>
+    <module>plugins/de.cognicrypt.staticanalyzer/</module>
+    <module>features/de.cognicrypt.codegenerator.feature/</module>
+    <module>features/de.cognicrypt.cryslhandler.feature/</module>
+    <module>features/de.cognicrypt.staticanalyzer.feature/</module>
+    <module>repository/</module>
   </modules>
 </project>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../mvn-parent/</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>
 	<build>

--- a/shippable.yml
+++ b/shippable.yml
@@ -2,18 +2,17 @@ language: java
 
 jdk:
   - oraclejdk8
-  
+
 build:
   ci:
    - cd mvn-parent
-   - mvn clean verify surefire:test --fail-at-end
-   
+   - mvn clean verify surefire:test cobertura:cobertura --fail-at-end
+
   on_success:
   #### THIS CURRENTLY USES SSHPASS FOR AUTHENTICATION! THIS IS INSECURE! FULLY SWITCH TO USING ONLY SSH KEYS ASAP! ####
    - if [ "$BRANCH" == "CurrentlyOutOfOrder" ]; then sudo apt-get install sshpass; cd ../repository; chmod +x upload.sh; ./upload.sh; fi
-   
+
 resources:
   - name: eclipseFTPkv
     type: integration
     integrationName: UpdateSitePassword
-

--- a/shippable.yml
+++ b/shippable.yml
@@ -5,7 +5,6 @@ jdk:
 
 build:
   ci:
-   - cd mvn-parent
    - mvn clean verify surefire:test cobertura:cobertura --fail-at-end
 
   on_success:


### PR DESCRIPTION
Fixes #199 

# Description

Adds code coverage reports to Shippable output by using the Cobertura Maven plugin. I have also changed the version of Maven Compiler plugin from 2.5.1 to 3.5.1 because I could not generate coverage reports with that version. Furthermore, I changed the location of the Parent POM from the folder of "mvn-parent" to the root directory of CogniCrypt. This is because I could not generate coverage reports of all plugins with the previous location of parent POM.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Eclipse Version:
* Java Version:
* OS:

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

