### PR TITLE
Fix for issue#47

### DIFF
--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/actions/WizardAction.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/actions/WizardAction.java
@@ -28,6 +28,8 @@ import de.cognicrypt.core.Constants;
  */
 public class WizardAction implements IWorkbenchWindowActionDelegate {
 
+	private Shell shell;
+
 	/**
 	 * The constructor.
 	 */
@@ -47,7 +49,9 @@ public class WizardAction implements IWorkbenchWindowActionDelegate {
 	 * @see IWorkbenchWindowActionDelegate#init
 	 */
 	@Override
-	public void init(final IWorkbenchWindow window) {}
+	public void init(final IWorkbenchWindow window) {
+		this.shell=window.getShell();
+	}
 
 	/**
 	 * The action has been activated. The argument of the method represents the 'real' action sitting in the workbench UI.
@@ -57,7 +61,7 @@ public class WizardAction implements IWorkbenchWindowActionDelegate {
 	@Override
 	public void run(final IAction action) {
 		Constants.WizardActionFromContextMenuFlag = false;
-		final CogniCryptWizardDialog dialog = new CogniCryptWizardDialog(new Shell(), new ConfiguratorWizard()) {
+		final CogniCryptWizardDialog dialog = new CogniCryptWizardDialog(shell, new ConfiguratorWizard()) {
 
 			@Override
 			protected void configureShell(Shell newShell) {

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/actions/WizardActionFromContextMenu.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/actions/WizardActionFromContextMenu.java
@@ -28,6 +28,8 @@ import de.cognicrypt.core.Constants;
  */
 public class WizardActionFromContextMenu implements IWorkbenchWindowActionDelegate {
 
+	private Shell shell;
+
 	/**
 	 * The constructor.
 	 */
@@ -47,7 +49,9 @@ public class WizardActionFromContextMenu implements IWorkbenchWindowActionDelega
 	 * @see IWorkbenchWindowActionDelegate#init
 	 */
 	@Override
-	public void init(final IWorkbenchWindow window) {}
+	public void init(final IWorkbenchWindow window) {
+		this.shell=window.getShell();
+	}
 
 	/**
 	 * The action has been activated. The argument of the method represents the 'real' action sitting in the workbench UI.
@@ -57,7 +61,7 @@ public class WizardActionFromContextMenu implements IWorkbenchWindowActionDelega
 	@Override
 	public void run(final IAction action) {
 		Constants.WizardActionFromContextMenuFlag = true;
-		final CogniCryptWizardDialog dialog = new CogniCryptWizardDialog(new Shell(), new ConfiguratorWizard());
+		final CogniCryptWizardDialog dialog = new CogniCryptWizardDialog(shell, new ConfiguratorWizard());
 		
 		dialog.open();
 	}


### PR DESCRIPTION
# Description

For the Unintended blank window on wizard invocation issue#47 , previous code used to create a new shell each time on an invocation in the "WizardAction.java" and "WizardActionFromContextMenu.java" files. The fix was to just catch the receiving window and use that.


Fixes # (issue) :47

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


* Eclipse Version: 4.8.0
* Java Version: 1.8.0.171
* OS: Ubuntu 18.04


